### PR TITLE
Fix problem with class shadowing on 2.13.2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.13.0
+  - 2.13.1
 
 jdk:
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val test = project
   .settings(
     skip.in(publish) := true,
     projectSettings,
-    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3"),
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full),
     scalacOptions ++= {
       val jar = (core / Compile / packageBin).value
       Seq(s"-Xplugin:${jar.getAbsolutePath}", s"-Jdummy=${jar.lastModified}") // ensures recompile
@@ -58,6 +58,6 @@ lazy val projectSettings = Seq(
   developers := List(
     Developer("augustjune", "Yura Slinkin", "jurij.jurich@gmail.com", url("https://github.com/augustjune"))
   ),
-  scalaVersion := "2.13.0",
+  scalaVersion := "2.13.1",
   crossScalaVersions := Seq(scalaVersion.value, "2.12.10", "2.11.12")
 )

--- a/test/src/main/scala/tests/shadowed.scala
+++ b/test/src/main/scala/tests/shadowed.scala
@@ -1,0 +1,11 @@
+package tests
+
+class parent[F[_]: Monad] {
+  def work: F[Int] = F.pure(21)
+}
+
+// starting from Scala 2.13.2 on, this would result in a warning if the class for context-applied had a name
+// derived only from the bounds itself as both parent and shadowed would define a class with the same name
+class shadowed[F[_]: Monad] extends parent[F] {
+  override def work: F[Int] = F.pure(42)
+}


### PR DESCRIPTION
Starting from Scala 2.13.2, it is no longer allowed to define an inner class with the same name as an inner class in the super class of the outer: https://github.com/scala/bug/issues/8353

As context-applied generates such class names when you extend a class which has a context bound with the same name, it generates a warning, for example in https://github.com/profunktor/redis4cats/issues/244. This PR fixes that by appending the outer class' name to make it unique.

Includes as well:
* Update Scala to 2.13.1
* Update kind-projector to 0.11.0

To reproduce the problem itself, do the following:
1. Fix kind-projector to `"org.typelevel" % "kind-projector_2.13.1" % "0.11.0"`
2. Open a sbt session
3. `set ThisBuild/resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"`
4. `++2.13.2-bin-53ba87a!`
5. `compile` - fails on the new test in `shadowed.scala`