### PR TITLE
Use an accessor that is not private in 2.13.14

### DIFF
--- a/core/src/main/scala/plugin/ContextApplied.scala
+++ b/core/src/main/scala/plugin/ContextApplied.scala
@@ -132,7 +132,7 @@ class ContextPlugin(plugin: Plugin, val global: Global)
       else ValDef(Modifiers(SYNTHETIC | ARTIFACT), TermName(name), Ident(typeName), Literal(Constant(null)))
 
     private def importModule(name: String): Tree =
-      Import(Ident(TermName(name)), List(ImportSelector.wild))
+      Import(Ident(TermName(name)), ImportSelector.wildList)
 
     private def insertAfterConstructor(body: List[Tree], insert: List[Tree]): List[Tree] =
       body match {


### PR DESCRIPTION
Fix for this plugin on Scala 2.13.14 (and possibly 2.13.13)

I can't test whether this will work in e.g. 2.11 as my JVM is too new. With upgrades to scala and kind-projector versions it works for me, I'll PR those as well if you prefer, but thought it was worth isolating the fix if you don't want to upgrade everything else too.